### PR TITLE
Fix version file problems

### DIFF
--- a/ShieldedPicoPort.version
+++ b/ShieldedPicoPort.version
@@ -1,43 +1,36 @@
 {
-	"NAME": "Shielded PicoPort (SPP)",
-	"URL": "https://github.com/zer0Kerbal/ShieldedPicoPort/ShieldedPicoPort.version",
-	"DOWNLOAD": "http://github.com/zer0Kerbal/ShieldedPicoPort/releases/latest",
-	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/zer0Kerbal/ShieldedPicoPort/master/Changelog.cfg",
-    "GITHUB":
-    {
-        "USERNAME":"zer0Kerbal",
-        "REPOSITORY":"ShieldedPicoPort",
-        "ALLOW_PRE_RELEASE":false
+    "NAME": "Shielded PicoPort (SPP)",
+    "URL": "https://github.com/zer0Kerbal/ShieldedPicoPort/raw/master/ShieldedPicoPort.version",
+    "DOWNLOAD": "http://github.com/zer0Kerbal/ShieldedPicoPort/releases/latest",
+    "CHANGE_LOG_URL": "https://raw.githubusercontent.com/zer0Kerbal/ShieldedPicoPort/master/Changelog.cfg",
+    "GITHUB": {
+        "USERNAME": "zer0Kerbal",
+        "REPOSITORY": "ShieldedPicoPort",
+        "ALLOW_PRE_RELEASE": false
     },
-	"VERSION":
-	{
-		"MAJOR":1,
-		"MINOR":0,
-		"PATCH":1,
-		"BUILD":0
-	},
-	"KSP_VERSION":
-	{
-		"MAJOR":1,
-		"MINOR":8,
-		"PATCH":1
-	},
-	"KSP_VERSION_MIN":
-	{
-		"MAJOR":1,
-		"MINOR":4,
-		"PATCH":1
-	},
-	"KSP_VERSION_MAX":
-	{
-		"MAJOR":1,
-		"MINOR":9,
-		"PATCH":9999
-	}
-},
-    "INSTALL_LOC":
-    {
-        "NAME":         "ShieldedPicoPort",
-        "DIRECTORY":    "GameData/KGEx/ShieldedPicoPort"
+    "VERSION": {
+        "MAJOR": 1,
+        "MINOR": 0,
+        "PATCH": 1,
+        "BUILD": 0
+    },
+    "KSP_VERSION": {
+        "MAJOR": 1,
+        "MINOR": 8,
+        "PATCH": 1
+    },
+    "KSP_VERSION_MIN": {
+        "MAJOR": 1,
+        "MINOR": 4,
+        "PATCH": 1
+    },
+    "KSP_VERSION_MAX": {
+        "MAJOR": 1,
+        "MINOR": 9,
+        "PATCH": 9999
+    },
+    "INSTALL_LOC": {
+        "NAME":      "ShieldedPicoPort",
+        "DIRECTORY": "GameData/KGEx/ShieldedPicoPort"
     }
 }


### PR DESCRIPTION
## Problem

This module has an inflation error in CKAN related to the version file:

![image](https://user-images.githubusercontent.com/1559108/76138384-4da3ad80-603f-11ea-9e08-16772253cc49.png)

Also the `"URL"` field is a 404, which prevents KSP-AVC and CKAN from checking for updated compatibility info.

## Cause

Syntax error, the `"INSTALL_LOC"` property is added outside/after the anonymous JSON object, so the file doesn't parse.

## Changes

Now the syntax is fixed by moving `"INSTALL_LOC"` inside the object.

And the `"URL"` field is fixed. And the indentation is now consistent (was mixed tabs+spaces before).

Note that either a new release or a replacement of the current download will be needed to fix the inflation error.

Tagging @zer0Kerbal because not everyone has notifications turned on for pull requests.

In case you're interested, @DasSkelett has developed a version file validator plugin for GitHub that can catch things like this before release, might be worth trying out:

- https://github.com/DasSkelett/AVC-VersionFileValidator